### PR TITLE
Opt sc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ byteorder = "1.4.3"
 thiserror = "2.0.11"
 once_cell = "1.18.0"
 itertools = "0.14.0"
+visibility = "0.1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", default-features = false, features = ["js"] }
@@ -67,7 +68,12 @@ harness = false
 name = "commit"
 harness = false
 
+[[bench]]
+name = "sumcheckeq"
+harness = false
+
 [features]
 default = ["halo2curves/asm"]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 experimental = []
+bench = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ byteorder = "1.4.3"
 thiserror = "2.0.11"
 once_cell = "1.18.0"
 itertools = "0.14.0"
-visibility = "0.1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", default-features = false, features = ["js"] }
@@ -76,4 +75,3 @@ harness = false
 default = ["halo2curves/asm"]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 experimental = []
-bench = []

--- a/benches/sumcheckeq.rs
+++ b/benches/sumcheckeq.rs
@@ -1,7 +1,5 @@
-//! Benchmarks Nova's prover for proving SHA-256 with varying sized messages.
-//! We run a single step with the step performing the entire computation.
-//! This code invokes a hand-written SHA-256 gadget from bellman/bellperson.
-//! It also uses code from bellman/bellperson to compare circuit-generated digest with sha2 crate's output
+//! Benchmarks Nova's prover for sumcheck involving equality polynomials.
+//! The optimization is described in Section 5 of https://eprint.iacr.org/2025/1117.
 #![allow(non_snake_case)]
 use criterion::*;
 use ff::Field;
@@ -81,7 +79,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
     .map(|i| <E as Engine>::Scalar::from(i * 8 as u64))
     .collect::<Vec<_>>();
 
-  for i in 1..MAX_NUM_VARS {
+  for i in 3..MAX_NUM_VARS {
     let mut group = c.benchmark_group(format!("NovaProve-PPSNARK-SumCheckEq-len-{}", i));
     group.sample_size(20);
 

--- a/benches/sumcheckeq.rs
+++ b/benches/sumcheckeq.rs
@@ -9,7 +9,7 @@ use nova_snark::{
   provider::Bn256EngineKZG,
   spartan::{
     ppsnark::{MemorySumcheckInstance, OuterSumcheckInstance},
-    EqPolynomial, SumcheckEngine,
+    SumcheckEngine,
   },
   traits::Engine,
 };
@@ -40,7 +40,7 @@ fn run_sc<E: Engine, S: SumcheckEngine<E>>(
 }
 
 fn bench_sumcheckeq(c: &mut Criterion) {
-  const MAX_NUM_VARS: usize = 25;
+  const MAX_NUM_VARS: usize = 26;
 
   let rs = (0..MAX_NUM_VARS)
     .map(|i| -<E as Engine>::Scalar::from(i as u64))
@@ -101,7 +101,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
 
         black_box({
           let mut instance = OuterSumcheckInstance::<E>::new(
-            EqPolynomial::new(taus).evals(),
+            taus,
             vs_a,
             vs_b,
             vs_c,
@@ -143,13 +143,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
         });
 
         black_box({
-          let mut instance = MemorySumcheckInstance::<E>::new(
-            polys1,
-            polys2,
-            EqPolynomial::new(taus).evals(),
-            poly3,
-            poly4,
-          );
+          let mut instance = MemorySumcheckInstance::<E>::new(polys1, polys2, taus, poly3, poly4);
           run_sc(&rs, &mut instance);
         });
       });

--- a/benches/sumcheckeq.rs
+++ b/benches/sumcheckeq.rs
@@ -44,7 +44,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
     .map(|i| -<E as Engine>::Scalar::from(i as u64))
     .collect::<Vec<_>>();
   let taus = (0..MAX_NUM_VARS)
-    .map(|i| -<E as Engine>::Scalar::from(2 * i as u64))
+    .map(|i| -<E as Engine>::Scalar::from(i as u64 * 2))
     .collect::<Vec<_>>();
   let vs_a = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
@@ -52,31 +52,31 @@ fn bench_sumcheckeq(c: &mut Criterion) {
     .collect::<Vec<_>>();
   let vs_b = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 2 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 2_u64))
     .collect::<Vec<_>>();
   let vs_c = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 3 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 3_u64))
     .collect::<Vec<_>>();
   let vs_d = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 4 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 4_u64))
     .collect::<Vec<_>>();
   let vs_e = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 5 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 5_u64))
     .collect::<Vec<_>>();
   let vs_f = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 6 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 6_u64))
     .collect::<Vec<_>>();
   let vs_g = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 7 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 7_u64))
     .collect::<Vec<_>>();
   let vs_h = (0..1 << MAX_NUM_VARS)
     .into_par_iter()
-    .map(|i| <E as Engine>::Scalar::from(i * 8 as u64))
+    .map(|i| <E as Engine>::Scalar::from(i * 8_u64))
     .collect::<Vec<_>>();
 
   for i in 3..MAX_NUM_VARS {
@@ -106,7 +106,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
             vs_d,
             &<E as Engine>::Scalar::ZERO,
           );
-          run_sc(&rs, &mut instance);
+          run_sc(&rs, &mut instance)
         });
       });
     });
@@ -142,7 +142,7 @@ fn bench_sumcheckeq(c: &mut Criterion) {
 
         black_box({
           let mut instance = MemorySumcheckInstance::<E>::new(polys1, polys2, taus, poly3, poly4);
-          run_sc(&rs, &mut instance);
+          run_sc(&rs, &mut instance)
         });
       });
     });

--- a/benches/sumcheckeq.rs
+++ b/benches/sumcheckeq.rs
@@ -1,0 +1,160 @@
+//! Benchmarks Nova's prover for proving SHA-256 with varying sized messages.
+//! We run a single step with the step performing the entire computation.
+//! This code invokes a hand-written SHA-256 gadget from bellman/bellperson.
+//! It also uses code from bellman/bellperson to compare circuit-generated digest with sha2 crate's output
+#![allow(non_snake_case)]
+use criterion::*;
+use ff::Field;
+use nova_snark::{
+  provider::Bn256EngineKZG,
+  spartan::{
+    ppsnark::{MemorySumcheckInstance, OuterSumcheckInstance},
+    EqPolynomial, SumcheckEngine,
+  },
+  traits::Engine,
+};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::hint::black_box;
+use std::time::Duration;
+
+type E = Bn256EngineKZG;
+
+criterion_group! {
+name = sumcheckeq;
+config = Criterion::default().warm_up_time(Duration::from_millis(3000));
+targets = bench_sumcheckeq
+}
+
+criterion_main!(sumcheckeq);
+
+fn run_sc<E: Engine, S: SumcheckEngine<E>>(
+  rs: &[E::Scalar],
+  instance: &mut S,
+) -> Vec<Vec<Vec<E::Scalar>>> {
+  let mut res = Vec::new();
+  for r in rs {
+    res.push(instance.evaluation_points());
+    instance.bound(r);
+  }
+  res
+}
+
+fn bench_sumcheckeq(c: &mut Criterion) {
+  const MAX_NUM_VARS: usize = 25;
+
+  let rs = (0..MAX_NUM_VARS)
+    .map(|i| -<E as Engine>::Scalar::from(i as u64))
+    .collect::<Vec<_>>();
+  let taus = (0..MAX_NUM_VARS)
+    .map(|i| -<E as Engine>::Scalar::from(2 * i as u64))
+    .collect::<Vec<_>>();
+  let vs_a = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i as u64))
+    .collect::<Vec<_>>();
+  let vs_b = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 2 as u64))
+    .collect::<Vec<_>>();
+  let vs_c = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 3 as u64))
+    .collect::<Vec<_>>();
+  let vs_d = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 4 as u64))
+    .collect::<Vec<_>>();
+  let vs_e = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 5 as u64))
+    .collect::<Vec<_>>();
+  let vs_f = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 6 as u64))
+    .collect::<Vec<_>>();
+  let vs_g = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 7 as u64))
+    .collect::<Vec<_>>();
+  let vs_h = (0..1 << MAX_NUM_VARS)
+    .into_par_iter()
+    .map(|i| <E as Engine>::Scalar::from(i * 8 as u64))
+    .collect::<Vec<_>>();
+
+  for i in 1..MAX_NUM_VARS {
+    let mut group = c.benchmark_group(format!("NovaProve-PPSNARK-SumCheckEq-len-{}", i));
+    group.sample_size(20);
+
+    group.bench_function("ProveOuter", |b| {
+      b.iter(|| {
+        let (rs, taus, vs_a, vs_b, vs_c, vs_d) = black_box({
+          let len = black_box(1 << i);
+          (
+            rs[..i].to_vec(),
+            taus[..i].to_vec(),
+            vs_a[..len].to_vec(),
+            vs_b[..len].to_vec(),
+            vs_c[..len].to_vec(),
+            vs_d[..len].to_vec(),
+          )
+        });
+
+        black_box({
+          let mut instance = OuterSumcheckInstance::<E>::new(
+            EqPolynomial::new(taus).evals(),
+            vs_a,
+            vs_b,
+            vs_c,
+            vs_d,
+            &<E as Engine>::Scalar::ZERO,
+          );
+          run_sc(&rs, &mut instance);
+        });
+      });
+    });
+
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("NovaProve-PPSNARK-SumCheckEq-len-{}", i));
+    group.sample_size(20);
+
+    group.bench_function("ProveMemory", |b| {
+      b.iter(|| {
+        let (rs, taus, polys1, polys2, poly3, poly4) = black_box({
+          let len = black_box(1 << i);
+          (
+            rs[..i].to_vec(),
+            taus[..i].to_vec(),
+            [
+              vs_a[..len].to_vec(),
+              vs_b[..len].to_vec(),
+              vs_c[..len].to_vec(),
+              vs_d[..len].to_vec(),
+            ],
+            [
+              vs_e[..len].to_vec(),
+              vs_f[..len].to_vec(),
+              vs_g[..len].to_vec(),
+              vs_h[..len].to_vec(),
+            ],
+            vs_a[..len].to_vec(),
+            vs_b[..len].to_vec(),
+          )
+        });
+
+        black_box({
+          let mut instance = MemorySumcheckInstance::<E>::new(
+            polys1,
+            polys2,
+            EqPolynomial::new(taus).evals(),
+            poly3,
+            poly4,
+          );
+          run_sc(&rs, &mut instance);
+        });
+      });
+    });
+
+    group.finish();
+  }
+}

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -15,6 +15,11 @@ pub(crate) mod math;
 pub(crate) mod polys;
 pub(crate) mod sumcheck;
 
+#[cfg(feature = "bench")]
+pub use polys::eq::EqPolynomial;
+#[cfg(feature = "bench")]
+pub use sumcheck::SumcheckEngine;
+
 use crate::{
   r1cs::{R1CSShape, SparseMatrix},
   traits::Engine,

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -15,7 +15,6 @@ pub(crate) mod math;
 pub(crate) mod polys;
 pub(crate) mod sumcheck;
 
-#[cfg(feature = "bench")]
 pub use sumcheck::SumcheckEngine;
 
 use crate::{

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -16,8 +16,6 @@ pub(crate) mod polys;
 pub(crate) mod sumcheck;
 
 #[cfg(feature = "bench")]
-pub use polys::eq::EqPolynomial;
-#[cfg(feature = "bench")]
 pub use sumcheck::SumcheckEngine;
 
 use crate::{

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -557,15 +557,11 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
         &self.t_plus_r_inv_row,
         &self.t_plus_r_row,
         &self.ts_row,
-        |[a, b, c]: [E::Scalar; 3]| a * b - c,
       );
     // 0 = ∑ eq[i] * (inv_W[i] * (T[i] + r) - 1))
-    let (eval_W_0_row, eval_W_2_row, eval_W_3_row) =
-      self.eq_sumcheck.evaluation_points_cubic_with_two_inputs(
-        &self.w_plus_r_inv_row,
-        &self.w_plus_r_row,
-        |[a, b]: [E::Scalar; 2]| a * b - E::Scalar::ONE,
-      );
+    let (eval_W_0_row, eval_W_2_row, eval_W_3_row) = self
+      .eq_sumcheck
+      .evaluation_points_cubic_with_two_inputs(&self.w_plus_r_inv_row, &self.w_plus_r_row);
 
     // column related evaluation points
     let (eval_T_0_col, eval_T_2_col, eval_T_3_col) =
@@ -573,14 +569,10 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
         &self.t_plus_r_inv_col,
         &self.t_plus_r_col,
         &self.ts_col,
-        |[a, b, c]: [E::Scalar; 3]| a * b - c,
       );
-    let (eval_W_0_col, eval_W_2_col, eval_W_3_col) =
-      self.eq_sumcheck.evaluation_points_cubic_with_two_inputs(
-        &self.w_plus_r_inv_col,
-        &self.w_plus_r_col,
-        |[a, b]: [E::Scalar; 2]| a * b - E::Scalar::ONE,
-      );
+    let (eval_W_0_col, eval_W_2_col, eval_W_3_col) = self
+      .eq_sumcheck
+      .evaluation_points_cubic_with_two_inputs(&self.w_plus_r_inv_col, &self.w_plus_r_col);
 
     vec![
       vec![eval_inv_0_row, eval_inv_2_row, eval_inv_3_row],
@@ -679,13 +671,9 @@ impl<E: Engine> SumcheckEngine<E> for OuterSumcheckInstance<E> {
   }
 
   fn evaluation_points(&self) -> Vec<Vec<E::Scalar>> {
-    let (eval_point_h_0, eval_point_h_2, eval_point_h_3) =
-      self.eq_sumcheck.evaluation_points_cubic_with_three_inputs(
-        &self.poly_Az,
-        &self.poly_Bz,
-        &self.poly_uCz_E,
-        &|[a, b, c]: [E::Scalar; 3]| a * b - c,
-      );
+    let (eval_point_h_0, eval_point_h_2, eval_point_h_3) = self
+      .eq_sumcheck
+      .evaluation_points_cubic_with_three_inputs(&self.poly_Az, &self.poly_Bz, &self.poly_uCz_E);
 
     let (eval_point_e_0, eval_point_e_2, eval_point_e_3) = self
       .eq_sumcheck

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -487,7 +487,7 @@ impl<E: Engine> MemorySumcheckInstance<E> {
     let [t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_inv_col, w_plus_r_inv_col] = polys_oracle;
     let [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col] = polys_aux;
 
-    let zero = vec![E::Scalar::ZERO; rhos.len()];
+    let zero = vec![E::Scalar::ZERO; 1 << rhos.len()];
 
     Self {
       w_plus_r_row: MultilinearPolynomial::new(w_plus_r_row),

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -312,6 +312,8 @@ impl<E: Engine> SumcheckEngine<E> for WitnessBoundSumcheck<E> {
   }
 }
 
+#[cfg_attr(feature = "bench", visibility::make(pub))]
+/// Memory sumcheck instance for PPSNARK LogUp
 struct MemorySumcheckInstance<E: Engine> {
   // row
   w_plus_r_row: MultilinearPolynomial<E::Scalar>,
@@ -475,6 +477,7 @@ impl<E: Engine> MemorySumcheckInstance<E> {
     Ok((comm_vec, poly_vec, aux_poly_vec))
   }
 
+  /// Create a new memory sumcheck instance
   pub fn new(
     polys_oracle: [Vec<E::Scalar>; 4],
     polys_aux: [Vec<E::Scalar>; 4],
@@ -645,6 +648,8 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
   }
 }
 
+#[cfg_attr(feature = "bench", visibility::make(pub))]
+/// Outer sumcheck instance for PPSNARK
 struct OuterSumcheckInstance<E: Engine> {
   poly_tau: MultilinearPolynomial<E::Scalar>,
   poly_Az: MultilinearPolynomial<E::Scalar>,
@@ -658,6 +663,7 @@ struct OuterSumcheckInstance<E: Engine> {
 }
 
 impl<E: Engine> OuterSumcheckInstance<E> {
+  /// Create a new outer sumcheck instance
   pub fn new(
     tau: Vec<E::Scalar>,
     Az: Vec<E::Scalar>,

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -17,7 +17,7 @@ use crate::{
       univariate::{CompressedUniPoly, UniPoly},
     },
     powers,
-    sumcheck::{SumcheckEngine, SumcheckProof},
+    sumcheck::{eq_sumcheck::EqSumCheckInstance, SumcheckEngine, SumcheckProof},
     PolyEvalInstance, PolyEvalWitness,
   },
   traits::{
@@ -329,11 +329,10 @@ struct MemorySumcheckInstance<E: Engine> {
   w_plus_r_inv_col: MultilinearPolynomial<E::Scalar>,
   ts_col: MultilinearPolynomial<E::Scalar>,
 
-  // eq
-  poly_eq: MultilinearPolynomial<E::Scalar>,
-
   // zero polynomial
   poly_zero: MultilinearPolynomial<E::Scalar>,
+
+  eq_sumcheck: EqSumCheckInstance<E>,
 }
 
 impl<E: Engine> MemorySumcheckInstance<E> {
@@ -349,7 +348,7 @@ impl<E: Engine> MemorySumcheckInstance<E> {
   ///            = eq(tau)[row[i]] * gamma + addr_row[i]
   ///   T_col[i] = mem_col[i]      * gamma + i
   ///            = z[i]            * gamma + i
-  ///   W_col[i] = addr_col[i]     * gamma + addr_col[i]
+  ///   W_col[i] = L_col[i]     * gamma + addr_col[i]
   ///            = z[col[i]]       * gamma + addr_col[i]
   /// and
   ///   TS_row, TS_col are integer-valued vectors representing the number of reads
@@ -481,14 +480,14 @@ impl<E: Engine> MemorySumcheckInstance<E> {
   pub fn new(
     polys_oracle: [Vec<E::Scalar>; 4],
     polys_aux: [Vec<E::Scalar>; 4],
-    poly_eq: Vec<E::Scalar>,
+    rhos: Vec<E::Scalar>,
     ts_row: Vec<E::Scalar>,
     ts_col: Vec<E::Scalar>,
   ) -> Self {
     let [t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_inv_col, w_plus_r_inv_col] = polys_oracle;
     let [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col] = polys_aux;
 
-    let zero = vec![E::Scalar::ZERO; poly_eq.len()];
+    let zero = vec![E::Scalar::ZERO; rhos.len()];
 
     Self {
       w_plus_r_row: MultilinearPolynomial::new(w_plus_r_row),
@@ -501,8 +500,8 @@ impl<E: Engine> MemorySumcheckInstance<E> {
       t_plus_r_inv_col: MultilinearPolynomial::new(t_plus_r_inv_col),
       w_plus_r_inv_col: MultilinearPolynomial::new(w_plus_r_inv_col),
       ts_col: MultilinearPolynomial::new(ts_col),
-      poly_eq: MultilinearPolynomial::new(poly_eq),
       poly_zero: MultilinearPolynomial::new(zero),
+      eq_sumcheck: EqSumCheckInstance::new(rhos),
     }
   }
 }
@@ -533,20 +532,6 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
                      _poly_C_comp: &E::Scalar|
      -> E::Scalar { *poly_A_comp - *poly_B_comp };
 
-    let comb_func2 =
-      |poly_A_comp: &E::Scalar,
-       poly_B_comp: &E::Scalar,
-       poly_C_comp: &E::Scalar,
-       _poly_D_comp: &E::Scalar|
-       -> E::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - E::Scalar::ONE) };
-
-    let comb_func3 =
-      |poly_A_comp: &E::Scalar,
-       poly_B_comp: &E::Scalar,
-       poly_C_comp: &E::Scalar,
-       poly_D_comp: &E::Scalar|
-       -> E::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
-
     // inv related evaluation points
     // 0 = ∑ TS[i]/(T[i] + r) - 1/(W[i] + r)
     let (eval_inv_0_row, eval_inv_2_row, eval_inv_3_row) =
@@ -568,39 +553,33 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
     // row related evaluation points
     // 0 = ∑ eq[i] * (inv_T[i] * (T[i] + r) - TS[i]))
     let (eval_T_0_row, eval_T_2_row, eval_T_3_row) =
-      SumcheckProof::<E>::compute_eval_points_cubic_with_additive_term(
-        &self.poly_eq,
+      self.eq_sumcheck.evaluation_points_cubic_with_three_inputs(
         &self.t_plus_r_inv_row,
         &self.t_plus_r_row,
         &self.ts_row,
-        &comb_func3,
+        |[a, b, c]: [E::Scalar; 3]| a * b - c,
       );
     // 0 = ∑ eq[i] * (inv_W[i] * (T[i] + r) - 1))
     let (eval_W_0_row, eval_W_2_row, eval_W_3_row) =
-      SumcheckProof::<E>::compute_eval_points_cubic_with_additive_term(
-        &self.poly_eq,
+      self.eq_sumcheck.evaluation_points_cubic_with_two_inputs(
         &self.w_plus_r_inv_row,
         &self.w_plus_r_row,
-        &self.poly_zero,
-        &comb_func2,
+        |[a, b]: [E::Scalar; 2]| a * b - E::Scalar::ONE,
       );
 
     // column related evaluation points
     let (eval_T_0_col, eval_T_2_col, eval_T_3_col) =
-      SumcheckProof::<E>::compute_eval_points_cubic_with_additive_term(
-        &self.poly_eq,
+      self.eq_sumcheck.evaluation_points_cubic_with_three_inputs(
         &self.t_plus_r_inv_col,
         &self.t_plus_r_col,
         &self.ts_col,
-        &comb_func3,
+        |[a, b, c]: [E::Scalar; 3]| a * b - c,
       );
     let (eval_W_0_col, eval_W_2_col, eval_W_3_col) =
-      SumcheckProof::<E>::compute_eval_points_cubic_with_additive_term(
-        &self.poly_eq,
+      self.eq_sumcheck.evaluation_points_cubic_with_two_inputs(
         &self.w_plus_r_inv_col,
         &self.w_plus_r_col,
-        &self.poly_zero,
-        &comb_func2,
+        |[a, b]: [E::Scalar; 2]| a * b - E::Scalar::ONE,
       );
 
     vec![
@@ -625,10 +604,11 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
       &mut self.w_plus_r_col,
       &mut self.w_plus_r_inv_col,
       &mut self.ts_col,
-      &mut self.poly_eq,
     ]
     .par_iter_mut()
     .for_each(|poly| poly.bind_poly_var_top(r));
+
+    self.eq_sumcheck.bound(r);
   }
 
   fn final_claims(&self) -> Vec<Vec<E::Scalar>> {
@@ -651,7 +631,6 @@ impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
 #[cfg_attr(feature = "bench", visibility::make(pub))]
 /// Outer sumcheck instance for PPSNARK
 struct OuterSumcheckInstance<E: Engine> {
-  poly_tau: MultilinearPolynomial<E::Scalar>,
   poly_Az: MultilinearPolynomial<E::Scalar>,
   poly_Bz: MultilinearPolynomial<E::Scalar>,
   poly_uCz_E: MultilinearPolynomial<E::Scalar>,
@@ -659,7 +638,7 @@ struct OuterSumcheckInstance<E: Engine> {
   poly_Mz: MultilinearPolynomial<E::Scalar>,
   eval_Mz_at_tau: E::Scalar,
 
-  poly_zero: MultilinearPolynomial<E::Scalar>,
+  eq_sumcheck: EqSumCheckInstance<E>,
 }
 
 impl<E: Engine> OuterSumcheckInstance<E> {
@@ -672,15 +651,13 @@ impl<E: Engine> OuterSumcheckInstance<E> {
     Mz: Vec<E::Scalar>,
     eval_Mz_at_tau: &E::Scalar,
   ) -> Self {
-    let zero = vec![E::Scalar::ZERO; tau.len()];
     Self {
-      poly_tau: MultilinearPolynomial::new(tau),
       poly_Az: MultilinearPolynomial::new(Az),
       poly_Bz: MultilinearPolynomial::new(Bz),
       poly_uCz_E: MultilinearPolynomial::new(uCz_E),
       poly_Mz: MultilinearPolynomial::new(Mz),
       eval_Mz_at_tau: *eval_Mz_at_tau,
-      poly_zero: MultilinearPolynomial::new(zero),
+      eq_sumcheck: EqSumCheckInstance::new(tau),
     }
   }
 }
@@ -695,42 +672,24 @@ impl<E: Engine> SumcheckEngine<E> for OuterSumcheckInstance<E> {
   }
 
   fn size(&self) -> usize {
-    assert_eq!(self.poly_tau.len(), self.poly_Az.len());
-    assert_eq!(self.poly_tau.len(), self.poly_Bz.len());
-    assert_eq!(self.poly_tau.len(), self.poly_uCz_E.len());
-    assert_eq!(self.poly_tau.len(), self.poly_Mz.len());
-    self.poly_tau.len()
+    assert_eq!(self.poly_Az.len(), self.poly_Bz.len());
+    assert_eq!(self.poly_Az.len(), self.poly_uCz_E.len());
+    assert_eq!(self.poly_Az.len(), self.poly_Mz.len());
+    self.poly_Az.len()
   }
 
   fn evaluation_points(&self) -> Vec<Vec<E::Scalar>> {
-    let comb_func =
-      |poly_A_comp: &E::Scalar,
-       poly_B_comp: &E::Scalar,
-       poly_C_comp: &E::Scalar,
-       poly_D_comp: &E::Scalar|
-       -> E::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
-
     let (eval_point_h_0, eval_point_h_2, eval_point_h_3) =
-      SumcheckProof::<E>::compute_eval_points_cubic_with_additive_term(
-        &self.poly_tau,
+      self.eq_sumcheck.evaluation_points_cubic_with_three_inputs(
         &self.poly_Az,
         &self.poly_Bz,
         &self.poly_uCz_E,
-        &comb_func,
+        &|[a, b, c]: [E::Scalar; 3]| a * b - c,
       );
 
-    let comb_func2 = |poly_A_comp: &E::Scalar,
-                      poly_B_comp: &E::Scalar,
-                      _poly_C_comp: &E::Scalar|
-     -> E::Scalar { *poly_A_comp * *poly_B_comp };
-
-    let (eval_point_e_0, eval_point_e_2, eval_point_e_3) =
-      SumcheckProof::<E>::compute_eval_points_cubic(
-        &self.poly_tau,
-        &self.poly_Mz,
-        &self.poly_zero,
-        &comb_func2,
-      );
+    let (eval_point_e_0, eval_point_e_2, eval_point_e_3) = self
+      .eq_sumcheck
+      .evaluation_points_cubic_with_one_input(&self.poly_Mz);
 
     vec![
       vec![eval_point_h_0, eval_point_h_2, eval_point_h_3],
@@ -740,7 +699,6 @@ impl<E: Engine> SumcheckEngine<E> for OuterSumcheckInstance<E> {
 
   fn bound(&mut self, r: &E::Scalar) {
     [
-      &mut self.poly_tau,
       &mut self.poly_Az,
       &mut self.poly_Bz,
       &mut self.poly_uCz_E,
@@ -748,6 +706,8 @@ impl<E: Engine> SumcheckEngine<E> for OuterSumcheckInstance<E> {
     ]
     .par_iter_mut()
     .for_each(|poly| poly.bind_poly_var_top(r));
+
+    self.eq_sumcheck.bound(r);
   }
 
   fn final_claims(&self) -> Vec<Vec<E::Scalar>> {
@@ -1160,14 +1120,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       || {
         // a sum-check instance to prove the first claim
         let outer_sc_inst = OuterSumcheckInstance::new(
-          EqPolynomial::new(tau.clone()).evals(),
+          tau.clone(),
           Az.clone(),
           Bz.clone(),
           (0..Cz.len())
             .map(|i| U.u * Cz[i] + E[i])
             .collect::<Vec<E::Scalar>>(),
           w.p.clone(), // Mz = Az + r * Bz + r^2 * Cz
-          &u.e,        // eval_Az_at_tau + r * eval_Az_at_tau + r^2 * eval_Cz_at_tau
+          &u.e,        // eval_Az_at_tau + r * eval_Bz_at_tau + r^2 * eval_Cz_at_tau
         );
 
         // a sum-check instance to prove the second claim
@@ -1209,16 +1169,15 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
         // absorb the commitments
         transcript.absorb(b"l", &comm_mem_oracles.as_slice());
 
-        let rho = (0..num_rounds_sc)
+        let rho: Vec<<E as Engine>::Scalar> = (0..num_rounds_sc)
           .map(|_| transcript.squeeze(b"r"))
           .collect::<Result<Vec<_>, NovaError>>()?;
-        let poly_eq = MultilinearPolynomial::new(EqPolynomial::new(rho).evals());
 
         Ok::<_, NovaError>((
           MemorySumcheckInstance::new(
             mem_oracles.clone(),
             mem_aux,
-            poly_eq.Z,
+            rho,
             pk.S_repr.ts_row.clone(),
             pk.S_repr.ts_col.clone(),
           ),

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1169,7 +1169,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
         // absorb the commitments
         transcript.absorb(b"l", &comm_mem_oracles.as_slice());
 
-        let rho: Vec<<E as Engine>::Scalar> = (0..num_rounds_sc)
+        let rho = (0..num_rounds_sc)
           .map(|_| transcript.squeeze(b"r"))
           .collect::<Result<Vec<_>, NovaError>>()?;
 

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -522,10 +522,7 @@ pub(crate) mod eq_sumcheck {
           let mut v_next = prev.to_vec();
           v_next.par_extend(prev.par_iter().map(|v| *v * tau));
           let (first, last) = v_next.split_at_mut(prev.len());
-          first
-            .par_iter_mut()
-            .zip(last)
-            .for_each(|(a, b)| *a = *a - *b);
+          first.par_iter_mut().zip(last).for_each(|(a, b)| *a -= *b);
 
           result.push(v_next);
         }

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -485,6 +485,8 @@ impl<E: Engine> SumcheckProof<E> {
 }
 
 pub(crate) mod eq_sumcheck {
+  //! This module implements the sumcheck optimization for equality polynomials.
+  //! The optimization is described in Section 5 of https://eprint.iacr.org/2025/1117 algorithm 5.
   use crate::{spartan::polys::multilinear::MultilinearPolynomial, traits::Engine};
   use ff::{Field, PrimeField};
   use rayon::{iter::ZipEq, prelude::*, slice::Iter};

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -486,13 +486,14 @@ impl<E: Engine> SumcheckProof<E> {
 
 pub(crate) mod eq_sumcheck {
   use crate::{spartan::polys::multilinear::MultilinearPolynomial, traits::Engine};
-  use ff::Field;
-  use rayon::prelude::*;
+  use ff::{Field, PrimeField};
+  use rayon::{iter::ZipEq, prelude::*, slice::Chunks};
 
   pub struct EqSumCheckInstance<E: Engine> {
     // number of variables at first
-    l: usize,
+    init_num_vars: usize,
     first_half: usize,
+    second_half: usize,
     round: usize,
     taus: Vec<E::Scalar>,
     eval_eq_left: E::Scalar,
@@ -552,8 +553,9 @@ pub(crate) mod eq_sumcheck {
         .collect::<Vec<_>>();
 
       Self {
-        l,
+        init_num_vars: l,
         first_half,
+        second_half: l - first_half,
         round: 1,
         taus,
         eval_eq_left: E::Scalar::ONE,
@@ -561,13 +563,6 @@ pub(crate) mod eq_sumcheck {
         poly_eq_right,
         eq_tau_0_2_3,
       }
-    }
-
-    #[inline]
-    pub fn bound(&mut self, r: &E::Scalar) {
-      let tau = self.taus[self.round - 1];
-      self.eval_eq_left *= E::Scalar::ONE - tau - r + (*r * tau).double();
-      self.round += 1;
     }
 
     #[inline]
@@ -581,98 +576,74 @@ pub(crate) mod eq_sumcheck {
     where
       F: Fn([E::Scalar; 3]) -> E::Scalar + Sync,
     {
-      assert_eq!(poly_A.len() % 2, 0);
+      debug_assert_eq!(poly_A.len() % 2, 0);
 
       let in_first_half = self.round < self.first_half;
 
-      let (poly_eq_left, poly_eq_right, right_len, second_half) = if in_first_half {
-        let second_half = self.l - self.first_half;
-        let poly_eq_left = &self.poly_eq_left[self.first_half - self.round];
-        let poly_eq_right = &self.poly_eq_right[second_half];
-        let right_len = poly_eq_right.len();
-        assert_eq!(right_len, 1 << second_half);
-        (poly_eq_left, poly_eq_right, right_len, second_half)
-      } else {
-        let poly_eq_right = &self.poly_eq_right[self.l - self.round];
-        (poly_eq_right, poly_eq_right, 0, 0)
-      };
-
       let half_p = poly_A.Z.len() / 2;
 
-      let (zero_A, one_A) = poly_A.Z.split_at(half_p);
-      let (zero_B, one_B) = poly_B.Z.split_at(half_p);
-      let (zero_C, one_C) = poly_C.Z.split_at(half_p);
+      let chunk_size = 100;
 
-      let zip_A = zero_A.par_iter().zip(one_A);
-      let zip_B = zero_B.par_iter().zip(one_B);
-      let zip_C = zero_C.par_iter().zip(one_C);
+      let [zip_A, zip_B, zip_C] =
+        split_and_zip_chunks([&poly_A.Z, &poly_B.Z, &poly_C.Z], half_p, chunk_size);
 
-      let (partial_eval_0, partial_eval_2, partial_eval_3) = zip_A
-        .zip(zip_B)
-        .zip(zip_C)
-        .enumerate()
-        .map(
-          |(i, (((zero_a, one_a), (zero_b, one_b)), (zero_c, one_c)))| {
-            let one_a_double = one_a.double();
-            let one_b_double = one_b.double();
-            let one_c_double = one_c.double();
-            let one_a_triple = one_a_double + one_a;
-            let one_b_triple = one_b_double + one_b;
-            let one_c_triple = one_c_double + one_c;
-            let zero_a_double = zero_a.double();
-            let zero_b_double = zero_b.double();
-            let zero_c_double = zero_c.double();
+      let (mut eval_0, mut eval_2, mut eval_3) = if in_first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
 
-            let e_a_0 = *zero_a;
-            let e_b_0 = *zero_b;
-            let e_c_0 = *zero_c;
+        zip_A
+          .zip_eq(zip_B)
+          .zip_eq(zip_C)
+          .enumerate()
+          .map(|(chunk_id, ((a, b), c))| {
+            let (zero_a, one_a) = a;
+            let (zero_b, one_b) = b;
+            let (zero_c, one_c) = c;
 
-            let e_a_2 = one_a_double - zero_a;
-            let e_b_2 = one_b_double - zero_b;
-            let e_c_2 = one_c_double - zero_c;
+            let offset = chunk_id * chunk_size;
 
-            let e_a_3 = one_a_triple - zero_a_double;
-            let e_b_3 = one_b_triple - zero_b_double;
-            let e_c_3 = one_c_triple - zero_c_double;
+            process_chunk_cubic_first_half(
+              [zero_a, zero_b, zero_c],
+              [one_a, one_b, one_c],
+              poly_eq_left,
+              poly_eq_right,
+              offset,
+              second_half,
+              low_mask,
+              &comb_func,
+            )
+          })
+          .reduce(
+            || (E::Scalar::ZERO, E::Scalar::ZERO, E::Scalar::ZERO),
+            |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+          )
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half().par_chunks(chunk_size);
 
-            let mut eval_0 = comb_func([e_a_0, e_b_0, e_c_0]);
-            let mut eval_2 = comb_func([e_a_2, e_b_2, e_c_2]);
-            let mut eval_3 = comb_func([e_a_3, e_b_3, e_c_3]);
+        zip_A
+          .zip_eq(zip_B)
+          .zip_eq(zip_C)
+          .zip_eq(poly_eq_right)
+          .map(|(((a, b), c), poly_eq_right)| {
+            let (zero_a, one_a) = a;
+            let (zero_b, one_b) = b;
+            let (zero_c, one_c) = c;
 
-            let factor = if in_first_half {
-              let left_id = i >> second_half;
-              let right_id = i % right_len;
-              assert_eq!(i, left_id * (1 << second_half) + right_id);
-              let left = poly_eq_left[left_id];
-              let right = poly_eq_right[right_id];
-              left * right
-            } else {
-              poly_eq_right[i]
-            };
+            process_chunk_cubic_last_half(
+              [zero_a, zero_b, zero_c],
+              [one_a, one_b, one_c],
+              poly_eq_right,
+              &comb_func,
+            )
+          })
+          .reduce(
+            || (E::Scalar::ZERO, E::Scalar::ZERO, E::Scalar::ZERO),
+            |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+          )
+      };
 
-            eval_0 *= factor;
-            eval_2 *= factor;
-            eval_3 *= factor;
+      self.update_evals(&mut eval_0, &mut eval_2, &mut eval_3);
 
-            (eval_0, eval_2, eval_3)
-          },
-        )
-        .reduce(
-          || (E::Scalar::ZERO, E::Scalar::ZERO, E::Scalar::ZERO),
-          |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
-        );
-
-      let p = self.eval_eq_left;
-      let eq_tau_0_2_3 = self.eq_tau_0_2_3[self.round - 1];
-      let eq_tau_0_p = eq_tau_0_2_3.0 * p;
-      let eq_tau_2_p = eq_tau_0_2_3.1 * p;
-      let eq_tau_3_p = eq_tau_0_2_3.2 * p;
-
-      (
-        partial_eval_0 * eq_tau_0_p,
-        partial_eval_2 * eq_tau_2_p,
-        partial_eval_3 * eq_tau_3_p,
-      )
+      (eval_0, eval_2, eval_3)
     }
 
     #[inline]
@@ -690,14 +661,14 @@ pub(crate) mod eq_sumcheck {
       let in_first_half = self.round < self.first_half;
 
       let (poly_eq_left, poly_eq_right, right_len, second_half) = if in_first_half {
-        let second_half = self.l - self.first_half;
+        let second_half = self.init_num_vars - self.first_half;
         let poly_eq_left = &self.poly_eq_left[self.first_half - self.round];
         let poly_eq_right = &self.poly_eq_right[second_half];
         let right_len = poly_eq_right.len();
         assert_eq!(right_len, 1 << second_half);
         (poly_eq_left, poly_eq_right, right_len, second_half)
       } else {
-        let poly_eq_right = &self.poly_eq_right[self.l - self.round];
+        let poly_eq_right = &self.poly_eq_right[self.init_num_vars - self.round];
         (poly_eq_right, poly_eq_right, 0, 0)
       };
 
@@ -778,14 +749,14 @@ pub(crate) mod eq_sumcheck {
       let in_first_half = self.round < self.first_half;
 
       let (poly_eq_left, poly_eq_right, right_len, second_half) = if in_first_half {
-        let second_half = self.l - self.first_half;
+        let second_half = self.init_num_vars - self.first_half;
         let poly_eq_left = &self.poly_eq_left[self.first_half - self.round];
         let poly_eq_right = &self.poly_eq_right[second_half];
         let right_len = poly_eq_right.len();
         assert_eq!(right_len, 1 << second_half);
         (poly_eq_left, poly_eq_right, right_len, second_half)
       } else {
-        let poly_eq_right = &self.poly_eq_right[self.l - self.round];
+        let poly_eq_right = &self.poly_eq_right[self.init_num_vars - self.round];
         (poly_eq_right, poly_eq_right, 0, 0)
       };
 
@@ -840,5 +811,159 @@ pub(crate) mod eq_sumcheck {
         partial_eval_3 * eq_tau_3_p,
       )
     }
+
+    #[inline]
+    pub fn bound(&mut self, r: &E::Scalar) {
+      let tau = self.taus[self.round - 1];
+      self.eval_eq_left *= E::Scalar::ONE - tau - r + (*r * tau).double();
+      self.round += 1;
+    }
+
+    #[inline]
+    fn update_evals(&self, eval_0: &mut E::Scalar, eval_2: &mut E::Scalar, eval_3: &mut E::Scalar) {
+      let p = self.eval_eq_left;
+      let eq_tau_0_2_3 = self.eq_tau_0_2_3[self.round - 1];
+      let eq_tau_0_p = eq_tau_0_2_3.0 * p;
+      let eq_tau_2_p = eq_tau_0_2_3.1 * p;
+      let eq_tau_3_p = eq_tau_0_2_3.2 * p;
+
+      *eval_0 *= eq_tau_0_p;
+      *eval_2 *= eq_tau_2_p;
+      *eval_3 *= eq_tau_3_p;
+    }
+
+    #[inline]
+    fn poly_eqs_first_half(&self) -> (&Vec<E::Scalar>, &Vec<E::Scalar>, usize, usize) {
+      let second_half = self.second_half;
+      let poly_eq_left = &self.poly_eq_left[self.first_half - self.round];
+      let poly_eq_right = &self.poly_eq_right[second_half];
+
+      debug_assert_eq!(poly_eq_right.len(), 1 << second_half);
+
+      (
+        poly_eq_left,
+        poly_eq_right,
+        second_half,
+        (1 << second_half) - 1,
+      )
+    }
+
+    #[inline]
+    fn poly_eq_right_last_half(&self) -> &Vec<E::Scalar> {
+      &self.poly_eq_right[self.init_num_vars - self.round]
+    }
+  }
+
+  #[inline]
+  fn split_and_zip_chunks<const N: usize, T: Sync>(
+    vec: [&[T]; N],
+    half_size: usize,
+    chunk_size: usize,
+  ) -> [ZipEq<Chunks<'_, T>, Chunks<'_, T>>; N] {
+    std::array::from_fn(|i| {
+      let (left, right) = vec[i].split_at(half_size);
+      left
+        .par_chunks(chunk_size)
+        .zip_eq(right.par_chunks(chunk_size))
+    })
+  }
+
+  #[inline]
+  fn process_chunk_cubic_first_half<const N: usize, Scalar: PrimeField, F>(
+    zero_chunks: [&[Scalar]; N],
+    one_chunks: [&[Scalar]; N],
+    poly_eq_left: &[Scalar],
+    poly_eq_right: &[Scalar],
+    offset: usize,
+    second_half: usize,
+    low_mask: usize,
+    comb_func: &F,
+  ) -> (Scalar, Scalar, Scalar)
+  where
+    F: Fn([Scalar; N]) -> Scalar,
+  {
+    let mut acc_eval_0 = Scalar::ZERO;
+    let mut acc_eval_2 = Scalar::ZERO;
+    let mut acc_eval_3 = Scalar::ZERO;
+
+    let n = zero_chunks[0].len();
+
+    for i in 0..n {
+      let zeros = std::array::from_fn(|j| zero_chunks[j][i]);
+      let ones = std::array::from_fn(|j| one_chunks[j][i]);
+
+      let (eval_0, eval_2, eval_3) = eval_one_case_cubic(zeros, ones, comb_func);
+
+      let id = offset + i;
+
+      let factor = poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
+
+      acc_eval_0 += eval_0 * factor;
+      acc_eval_2 += eval_2 * factor;
+      acc_eval_3 += eval_3 * factor;
+    }
+
+    (acc_eval_0, acc_eval_2, acc_eval_3)
+  }
+
+  #[inline]
+  fn process_chunk_cubic_last_half<const N: usize, Scalar: PrimeField, F>(
+    zero_chunks: [&[Scalar]; N],
+    one_chunks: [&[Scalar]; N],
+    poly_eq_right_chunk: &[Scalar],
+    comb_func: &F,
+  ) -> (Scalar, Scalar, Scalar)
+  where
+    F: Fn([Scalar; N]) -> Scalar,
+  {
+    let mut acc_eval_0 = Scalar::ZERO;
+    let mut acc_eval_2 = Scalar::ZERO;
+    let mut acc_eval_3 = Scalar::ZERO;
+
+    let n = zero_chunks[0].len();
+
+    for i in 0..n {
+      let zeros = std::array::from_fn(|j| zero_chunks[j][i]);
+      let ones: [_; N] = std::array::from_fn(|j| one_chunks[j][i]);
+
+      let (eval_0, eval_2, eval_3) = eval_one_case_cubic(zeros, ones, comb_func);
+
+      let factor = poly_eq_right_chunk[i];
+
+      acc_eval_0 += eval_0 * factor;
+      acc_eval_2 += eval_2 * factor;
+      acc_eval_3 += eval_3 * factor;
+    }
+
+    (acc_eval_0, acc_eval_2, acc_eval_3)
+  }
+
+  #[inline]
+  fn eval_one_case_cubic<const N: usize, Scalar: PrimeField, F>(
+    zeros: [Scalar; N],
+    ones: [Scalar; N],
+    comb_func: F,
+  ) -> (Scalar, Scalar, Scalar)
+  where
+    F: Fn([Scalar; N]) -> Scalar,
+  {
+    let eval_0 = {
+      let poly_bound_point = zeros;
+      comb_func(poly_bound_point)
+    };
+
+    let one_double = ones.iter().map(|one| one.double()).collect::<Vec<_>>();
+
+    let eval_2 = {
+      let poly_bound_point = std::array::from_fn(|i| one_double[i] - zeros[i]);
+      comb_func(poly_bound_point)
+    };
+
+    let eval_3 = {
+      let poly_bound_point = std::array::from_fn(|i| one_double[i] + ones[i] - zeros[i].double());
+      comb_func(poly_bound_point)
+    };
+
+    (eval_0, eval_2, eval_3)
   }
 }


### PR DESCRIPTION
Benchmark by `cargo bench --bench sumcheckeq`

```
group(num_vars/instance)   baseline                 optimized
-----                      -------                  ---
3/ProveMemory              1.31    374.2±5.17µs     1.00    285.7±3.06µs 
3/ProveOuter               1.13    195.7±7.95µs     1.00    172.9±1.94µs 
4/ProveMemory              1.46    583.4±7.97µs     1.00    400.5±4.75µs 
4/ProveOuter               1.31    302.4±2.81µs     1.00    230.4±4.60µs 
5/ProveMemory              1.52   814.0±12.49µs     1.00    536.3±5.71µs 
5/ProveOuter               1.39    415.0±7.12µs     1.00    299.3±5.04µs 
6/ProveMemory              1.57  1097.4±13.27µs     1.00    699.1±7.42µs 
6/ProveOuter               1.46    554.8±5.62µs     1.00    380.0±3.34µs 
7/ProveMemory              1.59  1431.5±16.04µs     1.00   897.7±10.94µs 
7/ProveOuter               1.51    720.1±7.30µs     1.00    478.0±5.76µs 
8/ProveMemory              1.63  1838.4±16.93µs     1.00   1129.0±9.22µs 
8/ProveOuter               1.55   917.4±11.52µs     1.00    593.7±8.06µs 
9/ProveMemory              1.64      2.3±0.04ms     1.00  1406.2±12.54µs 
9/ProveOuter               1.57   1142.6±9.88µs     1.00   728.7±13.68µs 
10/ProveMemory             1.63      2.8±0.04ms     1.00  1735.2±16.11µs 
10/ProveOuter              1.60  1407.1±14.24µs     1.00    878.5±8.45µs 
11/ProveMemory             1.61      3.5±0.03ms     1.00      2.2±0.04ms 
11/ProveOuter              1.59  1729.1±23.74µs     1.00  1087.0±18.51µs 
12/ProveMemory             1.61      4.3±0.04ms     1.00      2.7±0.02ms 
12/ProveOuter              1.59      2.1±0.05ms     1.00  1331.9±14.11µs 
13/ProveMemory             1.53      5.4±0.03ms     1.00      3.5±0.04ms 
13/ProveOuter              1.55      2.6±0.02ms     1.00  1676.2±22.96µs 
14/ProveMemory             1.49      7.0±0.04ms     1.00      4.7±0.05ms 
14/ProveOuter              1.50      3.3±0.02ms     1.00      2.2±0.02ms 
15/ProveMemory             1.41      9.4±0.07ms     1.00      6.7±0.07ms 
15/ProveOuter              1.43      4.3±0.04ms     1.00      3.0±0.03ms 
16/ProveMemory             1.33     13.9±0.16ms     1.00     10.5±0.16ms 
16/ProveOuter              1.41      6.3±0.07ms     1.00      4.5±0.06ms 
17/ProveMemory             1.25     21.9±0.30ms     1.00     17.6±0.28ms 
17/ProveOuter              1.33      9.5±0.10ms     1.00      7.2±0.08ms 
18/ProveMemory             1.19     36.9±0.43ms     1.00     31.1±1.85ms 
18/ProveOuter              1.30     15.7±0.20ms     1.00     12.1±0.13ms 
19/ProveMemory             1.13     60.8±0.46ms     1.00     53.6±0.45ms 
19/ProveOuter              1.18     24.4±0.25ms     1.00     20.7±1.37ms 
20/ProveMemory             1.03    117.4±0.95ms     1.00   113.9±18.57ms 
20/ProveOuter              1.21     48.9±0.45ms     1.00     40.3±0.92ms 
21/ProveMemory             1.07    229.9±2.36ms     1.00    215.5±6.14ms 
21/ProveOuter              1.10     92.4±1.61ms     1.00     84.1±7.30ms 
22/ProveMemory             1.06    447.8±5.23ms     1.00    422.1±4.91ms 
22/ProveOuter              1.12    178.5±2.07ms     1.00    159.2±9.55ms 
23/ProveMemory             1.05   882.8±22.83ms     1.00   836.9±11.99ms 
23/ProveOuter              1.15    352.1±3.67ms     1.00    305.0±5.95ms 
24/ProveMemory             1.04  1757.0±19.87ms     1.00  1682.2±20.25ms 
24/ProveOuter              1.15   701.6±13.97ms     1.00   611.0±15.54ms 
25/ProveMemory             1.05       3.6±0.06s     1.00       3.4±0.08s 
25/ProveOuter              1.14  1445.6±16.23ms     1.00  1263.3±18.22ms
```

There are 2 sumcheck-eq in one `ProverOuter` instance.
There are 4 sumcheck-eq (and 2 other sumcheck as well) in one `ProverMemory` instance.

Baseline commit: `3d3414`
